### PR TITLE
Encode alt attribute in HTML output

### DIFF
--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -143,7 +143,7 @@ class SI_Shortcodes {
         if ( 'true' == $bio && $user->bio != '' ) {
             $return .= '<div class="si_bio">' . $user->bio . '</div>';
         }
-        
+
         if ( 'true' == $website && $user->website != '' ) {
             $return .= '<div class="si_website"><a href="' . $user->website . '">View Website</a></div>';
         }
@@ -204,12 +204,12 @@ class SI_Shortcodes {
             $url = str_replace( 'http://', '//', $url );
 
             $return .= $wrapper == 'div' ? '<div class="si_item">' : '<li class="si_item">';
-            
+
             $return .= $link == 'true' ? '<a href="' . $image->link . '" target="_blank">' : null;
 
             $image_caption = is_object( $image->caption ) ? $image->caption->text : '';
 
-            $return .= '<img alt="' . $image_caption. '" src="' . $url . '" ' . $w_param . ' >';
+            $return .= '<img alt="' . htmlspecialchars ( $image_caption, ENT_QUOTES ) . '" src="' . $url . '" ' . $w_param . ' >';
 
             $return .= $link == 'true' ? '</a>' : null;
 

--- a/widgets/si-feed-widget.php
+++ b/widgets/si-feed-widget.php
@@ -14,7 +14,7 @@ class SI_Feed_Widget extends WP_Widget {
     public function SI_Feed_Widget() {
         $widget_ops  = array( 'classname' => 'si_feed_widget', 'description' => __( 'A widget to display your Instagram Feed', 'si_feed' ) );
         $control_ops = array( 'width' => 300, 'height' => 350, 'id_base' => 'si_feed_widget' );
-        
+
         $this->WP_Widget( 'si_feed_widget', __( 'Simple Instagram Feed Widget', 'si_feed' ), $widget_ops, $control_ops );
     }
 
@@ -55,7 +55,7 @@ class SI_Feed_Widget extends WP_Widget {
                 $return .= '<a href="' . $image->link . '" target="_blank">';
 
                 $image_caption = is_object( $image->caption ) ? $image->caption->text : '';
-                $return .= '<img alt="'. $image_caption . '" src="' . $url . '">';
+                $return .= '<img alt="'. htmlspecialchars ( $image_caption, ENT_QUOTES ) . '" src="' . $url . '">';
                 $return .= '</a>';
                 $return .= '</li>';
             }
@@ -64,7 +64,7 @@ class SI_Feed_Widget extends WP_Widget {
 
             $return .= '</div>';
 
-        } 
+        }
 
         echo $return;
 
@@ -93,11 +93,11 @@ class SI_Feed_Widget extends WP_Widget {
             <label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
                 <?php _e( 'Title:', 'simple-instagram' ); ?>
             </label>
-            <input 
-                id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" 
-                value="<?php echo esc_attr( $instance['title'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input
+                id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+                value="<?php echo esc_attr( $instance['title'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 
@@ -105,11 +105,11 @@ class SI_Feed_Widget extends WP_Widget {
             <label for="<?php echo esc_attr( $this->get_field_id( 'user' ) ); ?>">
                 <?php _e( 'User ID (leave blank to use your own feed):', 'simple-instagram' ); ?>
             </label>
-            <input 
-                id="<?php echo esc_attr( $this->get_field_id( 'user' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'user' ) ); ?>" 
-                value="<?php echo esc_attr( $instance['user'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input
+                id="<?php echo esc_attr( $this->get_field_id( 'user' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'user' ) ); ?>"
+                value="<?php echo esc_attr( $instance['user'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 
@@ -117,10 +117,10 @@ class SI_Feed_Widget extends WP_Widget {
             <label for="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>">
                 <?php _e( 'Number of Images (0 for Unmlimited):', 'simple-instagram' ); ?>
             </label>
-            <input id="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'count' ) ); ?>" 
-                value="<?php echo esc_attr( $instance['count'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input id="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'count' ) ); ?>"
+                value="<?php echo esc_attr( $instance['count'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 

--- a/widgets/si-popular-widget.php
+++ b/widgets/si-popular-widget.php
@@ -14,7 +14,7 @@ class SI_Popular_Widget extends WP_Widget {
     public function SI_Popular_Widget() {
         $widget_ops  = array( 'classname' => 'si_popular_widget', 'description' => __( 'A widget to display popular Instagram Images', 'si_popular' ) );
         $control_ops = array( 'width' => 300, 'height' => 350, 'id_base' => 'si_popular_widget' );
-        
+
         $this->WP_Widget( 'si_popular_widget', __( 'Simple Instagram Popular Widget', 'si_popular' ), $widget_ops, $control_ops );
     }
 
@@ -52,7 +52,7 @@ class SI_Popular_Widget extends WP_Widget {
                 $return .= '<li class="si_item">';
                 $return .= '<a href="' . $image->link . '" target="_blank">';
                 $image_caption = is_object( $image->caption ) ? $image->caption->text : '';
-                $return .= '<img alt="'. $image_caption . '" src="' . $url . '">';
+                $return .= '<img alt="'. htmlspecialchars ( $image_caption, ENT_QUOTES ) . '" src="' . $url . '">';
                 $return .= '</a>';
                 $return .= '</li>';
             }
@@ -67,7 +67,7 @@ class SI_Popular_Widget extends WP_Widget {
     }
 
     public function update( $new_instance, $old_instance ) {
-        
+
         $instance          = $old_instance;
         $instance['title'] = strip_tags( $new_instance['title'] );
         $instance['count'] = $new_instance['count'];
@@ -78,18 +78,18 @@ class SI_Popular_Widget extends WP_Widget {
     public function form( $instance ) {
 
         $defaults = array( 'title' => __( 'Popular from Instagram', 'simple-instagram' ), 'count' => __( '16', 'simple-instagram' ) );
-        $instance = wp_parse_args( (array) $instance, $defaults ); 
+        $instance = wp_parse_args( (array) $instance, $defaults );
         $style    = 'width:100%;'; ?>
 
         <p>
             <label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
                 <?php _e( 'Title:', 'simple-instagram' ); ?>
             </label>
-            <input 
-                id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'title' ) ) ?>" 
-                value="<?php echo esc_attr( $instance['title'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input
+                id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'title' ) ) ?>"
+                value="<?php echo esc_attr( $instance['title'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 
@@ -97,11 +97,11 @@ class SI_Popular_Widget extends WP_Widget {
             <label for="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>">
                 <?php _e( 'Number of Images (16 Maximum):', 'simple-instagram' ); ?>
             </label>
-            <input 
-                id="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'count' ) ); ?>" 
-                value="<?php echo esc_attr( $instance['count'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input
+                id="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'count' ) ); ?>"
+                value="<?php echo esc_attr( $instance['count'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 

--- a/widgets/si-tag-widget.php
+++ b/widgets/si-tag-widget.php
@@ -22,19 +22,19 @@ class SI_Tag_Widget extends WP_Widget {
 
         $title = apply_filters( 'widget_title', $instance['title'] );
         $count = $instance['count'];
-        
+
         if ( $count > 25 ) {
             $count = 25;
         }
 
         $tag = $instance['tag'];
-        
+
         echo $before_widget;
 
         if ( $title ) {
             echo $before_title . $title . $after_title;
         }
-        
+
         $instagram = new Simple_Instagram();
         $feed      = $instagram->get_tagged_media( $tag, $count );
 
@@ -53,7 +53,7 @@ class SI_Tag_Widget extends WP_Widget {
             $return .= '<li class="si_item">';
             $return .= '<a href="' . $image->link . '" target="_blank">';
             $image_caption = is_object( $image->caption ) ? $image->caption->text : '';
-            $return .= '<img alt="'. $image_caption . '" src="' . $url . '">';
+            $return .= '<img alt="'. htmlspecialchars ( $image_caption, ENT_QUOTES ) . '" src="' . $url . '">';
             $return .= '</a>';
             $return .= '</li>';
         }
@@ -78,18 +78,18 @@ class SI_Tag_Widget extends WP_Widget {
     public function form( $instance ) {
 
         $defaults = array( 'title' => __( 'From Instagram', 'simple-instagram' ), 'count' => __( '12', 'simple-instagram' ), 'tag' => __( 'food', 'simple-instagram' ) );
-        $instance = wp_parse_args( (array) $instance, $defaults ); 
+        $instance = wp_parse_args( (array) $instance, $defaults );
         $style    = 'width:100%;'; ?>
 
         <p>
             <label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
                 <?php _e( 'Title:', 'simple-instagram' ); ?>
             </label>
-            <input 
-                id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" 
-                value="<?php echo esc_attr( $instance['title'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input
+                id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+                value="<?php echo esc_attr( $instance['title'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 
@@ -97,11 +97,11 @@ class SI_Tag_Widget extends WP_Widget {
             <label for="<?php echo esc_attr( $this->get_field_id( 'tag' ) ); ?>">
                 <?php _e( 'Tag:', 'simple-instagram' ); ?>
             </label>
-            <input 
-                id="<?php echo esc_attr( $this->get_field_id( 'tag' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'tag' ) ); ?>" 
-                value="<?php echo esc_attr( $instance['tag'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input
+                id="<?php echo esc_attr( $this->get_field_id( 'tag' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'tag' ) ); ?>"
+                value="<?php echo esc_attr( $instance['tag'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 
@@ -109,11 +109,11 @@ class SI_Tag_Widget extends WP_Widget {
             <label for="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>">
                 <?php _e( 'Number of Images (25 Maximum):', 'simple-instagram' ); ?>
             </label>
-            <input 
-                id="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>" 
-                name="<?php echo esc_attr( $this->get_field_name( 'count' ) ); ?>" 
-                value="<?php echo esc_attr( $instance['count'] ); ?>" 
-                style="<?php echo esc_attr( $style ); ?>" 
+            <input
+                id="<?php echo esc_attr( $this->get_field_id( 'count' ) ); ?>"
+                name="<?php echo esc_attr( $this->get_field_name( 'count' ) ); ?>"
+                value="<?php echo esc_attr( $instance['count'] ); ?>"
+                style="<?php echo esc_attr( $style ); ?>"
             />
         </p>
 


### PR DESCRIPTION
Instagram users can put funky things into their Instagram comments/captions (such as quotes and ampersands, etc). Since the caption is used for the alt attribute in the returned output, encode the quotes and other funky things inside the alt attribute. This avoids double quotes inside the HTML attribute, for example and improves the chance of the page passing W3C validation.
